### PR TITLE
Node Ban Manager (nodejoin spam)

### DIFF
--- a/src/main/java/co/nyzo/verifier/MeshListener.java
+++ b/src/main/java/co/nyzo/verifier/MeshListener.java
@@ -540,14 +540,9 @@ public class MeshListener {
 
                     if (NodeBanManager.isActive()) {
 
-                        // Immediately ignore the node join message if the IP is banned.
-                        if (NodeBanManager.inBanlist(message.getSourceIpAddress())) {
-                            return null;
-                        }
-
                         NodeBanManager.trackJoin(message.getSourceIpAddress());
 
-                        // Run a final check and ignore the node join message if the IP is banned.
+                        // Ignore the node join message if the address is banned.
                         if (NodeBanManager.inBanlist(message.getSourceIpAddress())) {
                             return null;
                         }

--- a/src/main/java/co/nyzo/verifier/MeshListener.java
+++ b/src/main/java/co/nyzo/verifier/MeshListener.java
@@ -18,21 +18,6 @@ import java.util.function.BiFunction;
 
 public class MeshListener {
 
-    // Counter to keep track of received nodejoin messages.
-    // (IP as String) => (Number of nodejoin messages since last Cleanup)
-    private static HashMap<String, Integer> nodejoinCounters = new HashMap<String, Integer>(2000);
-
-    // Banned IPs
-    // (IP as String) => (Timestamp of ban)
-    private static HashMap<String, Integer> nodejoinBan = new HashMap<String, Integer>();
-
-    // Number of seconds after which the nodejoin counters are reset.
-    private static final int nodejoinClearInterval = 1200;
-
-    // If a nodejoin counter exceeds nodejoinBanThreshold it is banned.
-    // 20 messages per 1200 seconds (20 minutes) is far more than any verifier should send.
-    private static final int nodejoinBanThreshold = 20;
-
     private static final AtomicLong numberOfMessagesRejected = new AtomicLong(0);
     private static final AtomicLong numberOfMessagesAccepted = new AtomicLong(0);
 
@@ -141,8 +126,6 @@ public class MeshListener {
         if (!aliveUdp.getAndSet(true)) {
             startSocketThreadUdp();
         }
-
-	startBanCounterClearThread();
     }
 
     public static void startSocketThreadTcp() {
@@ -175,24 +158,6 @@ public class MeshListener {
                 aliveTcp.set(false);
             }
         }, "MeshListener-serverSocketTcp").start();
-    }
-
-    public static void startBanCounterClearThread() {
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-		for(;;) {
-                   try {
-			Thread.sleep(nodejoinClearInterval * 1000);
-			synchronized(MeshListener.class) {
-			   LogUtil.println("Clearing nodejoin counters. " + nodejoinCounters.size() + " removed");
-			   nodejoinCounters.clear();
-		        }
-                   } catch (Exception e) {
-                   }
-		}
-            }
-        }, "BanCounterClearThread").start();
     }
 
     private static void startSocketThreadUdp() {
@@ -573,28 +538,20 @@ public class MeshListener {
 
                 } else if (messageType == MessageType.NodeJoinV2_43) {
 
-		    String sourceIp = IpUtil.addressAsString(message.getSourceIpAddress());
+                    if (NodeBanManager.isActive()) {
 
-		    synchronized(MeshListener.class) {
-			// Is this IP already banned? Just ignore.
-			if(nodejoinBan.containsKey(sourceIp))
-			    return null;
+                        // Immediately ignore the node join message if the IP is banned.
+                        if (NodeBanManager.inBanlist(message.getSourceIpAddress())) {
+                            return null;
+                        }
 
-			if(nodejoinCounters.containsKey(sourceIp)) {
-			    // An entry already exists. Check if banThreshold is exceeded, then ban, otherwise increase counter by 1
-			    int counter = nodejoinCounters.get(sourceIp);
+                        NodeBanManager.trackJoin(message.getSourceIpAddress());
 
-			    if(counter > nodejoinBanThreshold) {
-				nodejoinBan.put(sourceIp, (int)(System.currentTimeMillis() / 1000));
-			        LogUtil.println("Banning IP " + sourceIp);
-			    } else {
-			        nodejoinCounters.put(sourceIp, counter + 1);
-			    }
-			} else {
-			    // First message. Create new entry.
-			    nodejoinCounters.put(sourceIp, 1);
-			}
-		    }
+                        // Run a final check and ignore the node join message if the IP is banned.
+                        if (NodeBanManager.inBanlist(message.getSourceIpAddress())) {
+                            return null;
+                        }
+                    }
 
                     NodeManager.updateNode(message);
 

--- a/src/main/java/co/nyzo/verifier/NodeBanManager.java
+++ b/src/main/java/co/nyzo/verifier/NodeBanManager.java
@@ -49,6 +49,11 @@ public class NodeBanManager {
         if (BlockManager.completedInitialization() && BlockManager.isCycleComplete() &&
                 !BlockManager.inGenesisCycle()) {
 
+            // No need to track connection counts if address is already banned.
+            if (inBanlist(ipAddress)) {
+                return;
+            }
+
             if (trackCounters.containsKey(ipAddress)) {
 
                 Map.Entry<Integer, Long> counter = trackCounters.get(ipAddress);

--- a/src/main/java/co/nyzo/verifier/NodeBanManager.java
+++ b/src/main/java/co/nyzo/verifier/NodeBanManager.java
@@ -19,7 +19,7 @@ public class NodeBanManager {
     private static final String trackMaxCountersKey = "node_track_max_counters";
     private static final int trackMaxCounters = PreferencesUtil.getInt(trackMaxCountersKey, 2000);
 
-    private static final String maintenanceMinutesKey = "node_maintenance_minutes";
+    private static final String maintenanceMinutesKey = "node_track_maintenance_minutes";
     private static final int maintenanceMinutes = PreferencesUtil.getInt(maintenanceMinutesKey, 5);
     private static final long maintenancePeriod = 1000L * 60L * maintenanceMinutes;
 

--- a/src/main/java/co/nyzo/verifier/NodeBanManager.java
+++ b/src/main/java/co/nyzo/verifier/NodeBanManager.java
@@ -1,0 +1,155 @@
+package co.nyzo.verifier;
+
+import co.nyzo.verifier.util.IpUtil;
+import co.nyzo.verifier.util.LogUtil;
+import co.nyzo.verifier.util.PreferencesUtil;
+
+import java.nio.ByteBuffer;
+import java.util.AbstractMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class NodeBanManager {
+
+    private static final String trackDurationMinutesKey = "node_track_duration_minutes";
+    private static final int trackDurationMinutes = PreferencesUtil.getInt(trackDurationMinutesKey, 20);
+    private static final long trackDuration = 1000L * 60L * trackDurationMinutes;
+
+    private static final String trackMaxCountersKey = "node_track_max_counters";
+    private static final int trackMaxCounters = PreferencesUtil.getInt(trackMaxCountersKey, 2000);
+
+    private static final String maintenanceMinutesKey = "node_maintenance_minutes";
+    private static final int maintenanceMinutes = PreferencesUtil.getInt(maintenanceMinutesKey, 5);
+    private static final long maintenancePeriod = 1000L * 60L * maintenanceMinutes;
+
+    private static final String banThresholdKey = "node_ban_threshold";
+    private static final int banThreshold = PreferencesUtil.getInt(banThresholdKey, 0);
+
+    private static final String banDurationMinutesKey = "node_ban_duration_minutes";
+    private static final int banDurationMinutes = PreferencesUtil.getInt(banDurationMinutesKey, 10);
+    private static final long banDuration = 1000L * 60L * banDurationMinutes;
+
+    private static final Map<ByteBuffer, Map.Entry<Integer, Long>> trackCounters = new ConcurrentHashMap<>(2000);
+    private static final Map<ByteBuffer, Long> bannedAddresses = new ConcurrentHashMap<>();
+
+    private static Long lastMaintenance = 0L;
+
+    public static boolean isActive() {
+        return banThreshold > 0;
+    }
+
+    public static synchronized void trackJoin(ByteBuffer ipAddress) {
+
+        // Skip tracking if disabled.
+        if (!isActive()) {
+            return;
+        }
+
+        if (BlockManager.completedInitialization() && BlockManager.isCycleComplete() &&
+                !BlockManager.inGenesisCycle()) {
+
+            if (trackCounters.containsKey(ipAddress)) {
+
+                Map.Entry<Integer, Long> counter = trackCounters.get(ipAddress);
+                int count = counter.getKey();
+                long timestamp = counter.getValue();
+
+                if (count > banThreshold) {
+
+                    LogUtil.println("nodejoin_ban " + IpUtil.addressAsString(ipAddress.array()));
+                    addToBanlist(ipAddress);
+                    trackCounters.remove(ipAddress);
+                } else {
+                    count = !isLapsed(timestamp, trackDuration) ? count + 1 : 1;
+                    trackCounters.put(ipAddress, new AbstractMap.SimpleEntry<>(count, System.currentTimeMillis()));
+                }
+            } else {
+                // System.out.println("Started tracking nodejoin counts for " + IpUtil.addressAsString(ipAddress.array()));
+                trackCounters.put(ipAddress, new AbstractMap.SimpleEntry<>(1, System.currentTimeMillis()));
+            }
+
+            // If the tracking counters exceeds configured maximum, perform maintenance.
+            if (trackCounters.size() > trackMaxCounters && isLapsed(lastMaintenance, maintenancePeriod)) {
+                performMaintenance();
+            }
+        }
+    }
+
+    public static synchronized void trackJoin(byte[] ipAddress) {
+        trackJoin(ByteBuffer.wrap(ipAddress));
+    }
+
+    public static boolean inBanlist(ByteBuffer ipAddress) {
+
+        // If bans are permanent, only check if address exists in list.
+        if (banDuration <= 0 && bannedAddresses.containsKey(ipAddress)) {
+            return true;
+        }
+
+        long timestamp = bannedAddresses.getOrDefault(ipAddress, 0L);
+        return !isLapsed(timestamp, banDuration);
+    }
+
+    public static boolean inBanlist(byte[] ipAddress) {
+        return inBanlist(ByteBuffer.wrap(ipAddress));
+    }
+
+    public static int getBanlistSize() {
+        return bannedAddresses.size();
+    }
+
+    public static void performMaintenance() {
+
+        // Skip maintenance if disabled.
+        if (!isActive()) {
+            return;
+        }
+
+        // System.out.println("Starting node ban maintenance");
+        lastMaintenance = System.currentTimeMillis();
+
+        // Remove expired entries from counter list.
+        for (Map.Entry<ByteBuffer, Map.Entry<Integer, Long>> entry : new HashSet<>(trackCounters.entrySet())) {
+            Map.Entry<Integer, Long> track = entry.getValue();
+            long timestamp = track.getValue();
+
+            if (isLapsed(timestamp, trackDuration)) {
+                // System.out.println("Stopped tracking nodejoin counts (Expired) for " + IpUtil.addressAsString(entry.getKey().array()));
+                trackCounters.remove(entry.getKey());
+            }
+        }
+
+        // Remove addresses of any nodes in the current cycle.
+        for (Node node : NodeManager.getMesh()) {
+            if (BlockManager.verifierInOrNearCurrentCycle(ByteBuffer.wrap(node.getIdentifier()))) {
+                ByteBuffer ipAddress = ByteBuffer.wrap(node.getIpAddress());
+                bannedAddresses.remove(ipAddress);
+            }
+        }
+
+        // Skip address removal as bans are permanent.
+        if (banDuration <= 0) {
+            return;
+        }
+
+        // Remove expired entries from ban list.
+        for (ByteBuffer address : new HashSet<>(bannedAddresses.keySet())) {
+            if (isLapsed(bannedAddresses.getOrDefault(address, 0L), banDuration)) {
+                LogUtil.println("nodejoin_unban " + IpUtil.addressAsString(address.array()));
+                bannedAddresses.remove(address);
+            }
+        }
+    }
+
+    private static void addToBanlist(ByteBuffer ipAddress) {
+
+        if (!bannedAddresses.containsKey(ipAddress)) {
+            bannedAddresses.put(ipAddress, System.currentTimeMillis());
+        }
+    }
+
+    private static boolean isLapsed(Long timestamp, Long duration) {
+        return System.currentTimeMillis() > timestamp + duration;
+    }
+}

--- a/src/main/java/co/nyzo/verifier/Verifier.java
+++ b/src/main/java/co/nyzo/verifier/Verifier.java
@@ -570,12 +570,13 @@ public class Verifier {
                         // Update vote counts for verifier removal.
                         VerifierRemovalManager.updateVoteCounts();
 
-                        // Perform blacklist, unfrozen block, consensus-tracker, and message (dynamic whitelist)
-                        // maintenance.
+                        // Perform blacklist, unfrozen block, consensus-tracker, message (dynamic whitelist), and
+                        // banlist (node join spam) maintenance.
                         BlacklistManager.performMaintenance();
                         UnfrozenBlockManager.performMaintenance();
                         ConsensusTracker.performMaintenance();
                         Message.performMaintenance();
+                        NodeBanManager.performMaintenance();
 
                         // Clean old transactions from the transaction pool.
                         TransactionPool.updateFrozenEdge();


### PR DESCRIPTION
This expands on #1, originally written by @dystophia. The logic has been moved to its own manager, called _NodeBanManager_ (similar to BlacklistManager). Additional changes include the ability to customize how it works via preferences.

**New preferences:**
- `node_track_duration_minutes` - Tracking for a node will expire after the allotted timeframe; **default 20 minutes**
- `node_track_max_counters` - A soft-cap (very) of how many concurrent nodes to track at one time; **default 2000**
- `node_track_maintenance_minutes` - How often to allow self-triggered maintenance to run; **default 5 minutes**
- `node_ban_threshold` - How many "nodejoin" requests to allow within `node_track_duration_minutes` before banning; **default 0**<sup>1</sup>
- `node_ban_duration_minutes` - How long to ban a node for exceeding `node_ban_threshold`; **default 10 minutes**<sup>2</sup>

**Notes:**
- <sup>1</sup> If `node_ban_threshold` is zero or less, _NodeBanManager_ is essentially disabled. This is the default.
- <sup>2</sup> If `node_ban_duration_minutes` is set to zero or less, the ban is permanent for the life of the application.

I have been testing this on some out-of-cycle verifiers, but unfortunately I do not have access to an in-cycle verifier to test against. A code review and some additional testing (out-of-cycle preferred for now) from others would be appreciated.

I am open to making changes and improvements. Thanks!